### PR TITLE
Fix Or Requireds not showing

### DIFF
--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -39,7 +39,6 @@
           </template>
           <ViewScores :scores="obj.scores" />
           <ViewRequirements :requireds="obj.requireds" />
-          <br />
           <div class="obj-text" v-html="formatText(obj.text)"></div>
         </div>
         <ViewAddon
@@ -182,6 +181,7 @@ const decrement = () => {
 
     .obj-text {
       text-align: center;
+      margin-top: 1rem;
     }
   }
 }

--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -39,6 +39,7 @@
           </template>
           <ViewScores :scores="obj.scores" />
           <ViewRequirements :requireds="obj.requireds" />
+          <br />
           <div class="obj-text" v-html="formatText(obj.text)"></div>
         </div>
         <ViewAddon

--- a/components/viewer/ViewRequirement.vue
+++ b/components/viewer/ViewRequirement.vue
@@ -5,11 +5,17 @@
     :class="{ disabled: !isEnabled }"
   >
     <span v-if="req.beforeText">{{ req.beforeText }}</span>
-    <div v-if="!reqId">
+    <div v-if="req.type === 'id'">
       <span>{{ getObject(req.reqId)?.title ?? '???' }}</span>
     </div>
+    <div v-else-if="req.type === 'or'">
+      <span v-for="(orReq, idx) in req.orRequired" :key="idx">
+        <span v-if="idx > 0">, or</span>
+        {{ getObject(orReq.req).title ?? '???' }}
+      </span>
+    </div>
     <div v-else>
-      <span>{{ getObject(reqId!).title }}</span>
+      Unknown Condition
     </div>
     <span v-if="req.afterText">{{ req.afterText }}</span>
   </div>

--- a/components/viewer/ViewRequirement.vue
+++ b/components/viewer/ViewRequirement.vue
@@ -5,7 +5,12 @@
     :class="{ disabled: !isEnabled }"
   >
     <span v-if="req.beforeText">{{ req.beforeText }}</span>
-    <span>{{ getObject(req.reqId)?.title ?? '???' }}</span>
+    <div v-if="!reqId">
+      <span>{{ getObject(req.reqId)?.title ?? '???' }}</span>
+    </div>
+    <div v-else>
+      <span>{{ getObject(reqId!).title }}</span>
+    </div>
     <span v-if="req.afterText">{{ req.afterText }}</span>
   </div>
 </template>
@@ -15,7 +20,7 @@ import { buildConditions } from '~/composables/conditions';
 import { ConditionTerm } from '~/composables/project';
 import { useProjectRefs, useProjectStore } from '~/composables/store/project';
 
-const { req } = defineProps<{ req: ConditionTerm }>();
+const { req, reqId } = defineProps<{ req: ConditionTerm; reqId?: string }>();
 
 const { getObject } = useProjectStore();
 

--- a/components/viewer/ViewRequirement.vue
+++ b/components/viewer/ViewRequirement.vue
@@ -11,12 +11,10 @@
     <div v-else-if="req.type === 'or'">
       <span v-for="(orReq, idx) in req.orRequired" :key="idx">
         <span v-if="idx > 0">, or</span>
-        {{ getObject(orReq.req).title ?? '???' }}
+        {{ getObject(orReq.req)?.title ?? '???' }}
       </span>
     </div>
-    <div v-else>
-      Unknown Condition
-    </div>
+    <div v-else>Unknown Condition</div>
     <span v-if="req.afterText">{{ req.afterText }}</span>
   </div>
 </template>
@@ -26,7 +24,7 @@ import { buildConditions } from '~/composables/conditions';
 import { ConditionTerm } from '~/composables/project';
 import { useProjectRefs, useProjectStore } from '~/composables/store/project';
 
-const { req, reqId } = defineProps<{ req: ConditionTerm; reqId?: string }>();
+const { req } = defineProps<{ req: ConditionTerm }>();
 
 const { getObject } = useProjectStore();
 

--- a/components/viewer/ViewRequirements.vue
+++ b/components/viewer/ViewRequirements.vue
@@ -1,18 +1,6 @@
 <template>
   <div v-if="requireds.length > 0" class="obj-requirements">
-    <div v-for="(req, idx) in requireds" :key="idx" :req="req">
-      <div v-if="req.type === 'id'">
-        <ViewRequirement :key="idx" :req="req" />
-      </div>
-      <div v-else-if="req.type === 'or'">
-        <ViewRequirement
-          v-for="(reqOr, idOr) in req.orRequired"
-          :key="idOr"
-          :req="req"
-          :req-id="reqOr.req"
-        />
-      </div>
-    </div>
+    <ViewRequirement v-for="(req, idx) in requireds" :key="idx" :req="req" />
   </div>
 </template>
 

--- a/components/viewer/ViewRequirements.vue
+++ b/components/viewer/ViewRequirements.vue
@@ -1,6 +1,18 @@
 <template>
   <div v-if="requireds.length > 0" class="obj-requirements">
-    <ViewRequirement v-for="(req, idx) in requireds" :key="idx" :req="req" />
+    <div v-for="(req, idx) in requireds" :key="idx" :req="req">
+      <div v-if="req.type === 'id'">
+        <ViewRequirement :key="idx" :req="req" />
+      </div>
+      <div v-else-if="req.type === 'or'">
+        <ViewRequirement
+          v-for="(reqOr, idOr) in req.orRequired"
+          :key="idOr"
+          :req="req"
+          :req-id="reqOr.req"
+        />
+      </div>
+    </div>
   </div>
 </template>
 


### PR DESCRIPTION
This pr fixes or requirements, such as objects that require "this" OR "that".

An example of this is the drawback "Childlike" requires `Pint Sized` OR `6 to 10 years old` OR `10 to 12 years old`.

Currently Childlike incorrectly shows its requirements as `???`, this pr properly displays the requirements of Childlike and various other objects that rely upon `orRequirements`.