### PR TITLE
Prevent Non-Selectable objects from being selected

### DIFF
--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -2,7 +2,11 @@
   <div :class="objClass">
     <div
       class="project-obj"
-      :class="{ selected: isSelected, disabled: !isEnabled }"
+      :class="{
+        selected: isSelected,
+        disabled: !isEnabled,
+        notSelectable: obj.isNotSelectable || row.isInfoRow,
+      }"
       @click="toggle"
     >
       <div class="project-obj-content">
@@ -159,6 +163,11 @@ const decrement = () => {
 
   &.disabled {
     background-color: gray;
+  }
+
+  &.notSelectable {
+    border: none;
+    border-radius: none;
   }
 
   .obj-image {

--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -105,7 +105,12 @@ const maxSelectedAmount = computed(() =>
 );
 
 const toggle = () => {
-  if (isEnabled.value && !obj.isSelectableMultiple) {
+  if (
+    isEnabled.value &&
+    !obj.isSelectableMultiple &&
+    !obj.isNotSelectable &&
+    !row.isInfoRow
+  ) {
     if (obj.activateOtherChoice) {
       R.split(',', obj.activateThisChoice).forEach((id) => {
         store.setSelected(id, !isSelected.value);

--- a/components/viewer/ViewProjectRow.vue
+++ b/components/viewer/ViewProjectRow.vue
@@ -61,6 +61,7 @@ const isVisible = computed(() => condition(selectedIds.value));
 
     .row-text {
       padding: 5px;
+      text-align: center;
     }
   }
 }

--- a/composables/project.ts
+++ b/composables/project.ts
@@ -47,6 +47,7 @@ export type ProjectObj = HasId &
     activateThisChoice: string;
 
     isSelectableMultiple: boolean;
+    isNotSelectable: boolean;
     numMultipleTimesMinus: string;
     numMultipleTimesPluss: string;
   };
@@ -62,6 +63,7 @@ export type ProjectRow = HasId &
 
     resultGroupId: string;
     allowedChoices: number;
+    isInfoRow: boolean;
 
     objects: ProjectObj[];
   };


### PR DESCRIPTION
This prevents objects like `Buy Shard Points` and rows like `Credits` from being selectable.