### PR TITLE
Fix objects that are selectable multiple times unselecting other objects

### DIFF
--- a/composables/store/project.ts
+++ b/composables/store/project.ts
@@ -84,7 +84,8 @@ export const useProjectStore = defineStore('project', () => {
     if (isSelected) {
       const rowId = getObjectRow.value(id);
       const row = getRow.value(rowId);
-      if (row.allowedChoices > 0) {
+      const obj = getObject.value(id);
+      if (row.allowedChoices > 0 && !obj.isSelectableMultiple) {
         const selectedRowObjects = R.intersection(
           R.keys(selected.value),
           R.map(R.prop('id'), row.objects),


### PR DESCRIPTION
When there's a row limit on max selectable items, objects that could be selected multiple times would unselect other objects.