### PR TITLE
Force show requirements only for addons

### DIFF
--- a/components/viewer/ViewAddon.vue
+++ b/components/viewer/ViewAddon.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="obj-addon" :class="{ disabled: !isEnabled }">
     <div class="obj-title">{{ addon.title }}</div>
-    <ViewRequirements :requireds="addon.requireds" />
+    <ViewRequirements :requireds="addon.requireds" :show-always="true" />
     <div class="obj-text">{{ addon.text }}</div>
   </div>
 </template>

--- a/components/viewer/ViewRequirement.vue
+++ b/components/viewer/ViewRequirement.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="req.showRequired || !req.id"
+    v-if="req.showRequired || showAlways"
     class="obj-requirement"
     :class="{ disabled: !isEnabled }"
   >
@@ -26,7 +26,10 @@ import { buildConditions } from '~/composables/conditions';
 import { ConditionTerm } from '~/composables/project';
 import { useProjectRefs, useProjectStore } from '~/composables/store/project';
 
-const { req } = defineProps<{ req: ConditionTerm }>();
+const { req, showAlways } = defineProps<{
+  req: ConditionTerm;
+  showAlways?: boolean;
+}>();
 
 const { getObject } = useProjectStore();
 

--- a/components/viewer/ViewRequirements.vue
+++ b/components/viewer/ViewRequirements.vue
@@ -1,6 +1,11 @@
 <template>
   <div v-if="requireds.length > 0" class="obj-requirements">
-    <ViewRequirement v-for="(req, idx) in requireds" :key="idx" :req="req" />
+    <ViewRequirement
+      v-for="(req, idx) in requireds"
+      :key="idx"
+      :req="req"
+      :show-always="showAlways"
+    />
   </div>
 </template>
 
@@ -8,7 +13,7 @@
 import ViewRequirement from '~/components/viewer/ViewRequirement.vue';
 import { ConditionTerm } from '~/composables/project';
 
-defineProps<{ requireds: ConditionTerm[] }>();
+defineProps<{ requireds: ConditionTerm[]; showAlways?: boolean }>();
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
I previously thought that addons were the only kind of object to not have ids on requirements. That was a misunderstanding. This pr makes it so only addons force requirements to show. 