### PR TITLE
Overflow with scrollbar in search

### DIFF
--- a/components/viewer/modal/SearchModal.vue
+++ b/components/viewer/modal/SearchModal.vue
@@ -198,6 +198,12 @@ const preview = (obj: ProjectObj, row: ProjectRow) => {
     align-items: stretch;
     justify-content: stretch;
     overflow: auto;
+    .project-obj {
+      overflow-y: scroll;
+    }
+    .project-obj-content {
+      overflow: unset;
+    }
   }
 
   .result-group {


### PR DESCRIPTION
This allows users to scroll the entire object if it overflows.

project-obj-content needs to be unset or it's styling overrides this. (which is undesirable for search specifically)
