### PR TITLE
Handle NOT requirements

### DIFF
--- a/composables/conditions.ts
+++ b/composables/conditions.ts
@@ -60,6 +60,13 @@ const buildCondition = (term: ConditionTerm): Condition => {
         return OR(R.map(SELECTED, ids));
       },
     )
+    .with(
+      { type: 'or', required: false, orRequired: P.select() },
+      (orRequired) => {
+        const ids = R.reject(R.isEmpty, R.map(R.prop('req'), orRequired));
+        return OR(R.map(UNSELECTED, ids));
+      },
+    )
     .otherwise(() => ALWAYS);
 
   if (isEmpty(term.requireds)) {


### PR DESCRIPTION
required: false indicates a not indicator for some reason (horribly named)

This fixes buildConditions to handle this case, instead of returning ALWAYS.
