### PR TITLE
Make requirements more grammatically correct

### DIFF
--- a/components/viewer/ViewRequirement.vue
+++ b/components/viewer/ViewRequirement.vue
@@ -11,7 +11,10 @@
     <div v-else-if="req.type === 'or'">
       <span v-for="(orReq, idx) in req.orRequired" :key="idx">
         <template v-if="orReq.req">
-          <span v-if="idx > 0">, or</span>
+          <span v-if="idx > 0"
+            >,
+            <span v-if="idx >= req.orRequired.length - 1">or</span>
+          </span>
           {{ getObject(orReq.req)?.title ?? '???' }}
         </template>
       </span>


### PR DESCRIPTION
This keeps `or` from showing until the last item in the requirements array.
