### PR TITLE
Fix objects not being scrollable when they overflow

### DIFF
--- a/components/viewer/modal/SearchModal.vue
+++ b/components/viewer/modal/SearchModal.vue
@@ -198,12 +198,6 @@ const preview = (obj: ProjectObj, row: ProjectRow) => {
     align-items: stretch;
     justify-content: stretch;
     overflow: auto;
-    .project-obj {
-      overflow-y: scroll;
-    }
-    .project-obj-content {
-      overflow: unset;
-    }
   }
 
   .result-group {
@@ -220,5 +214,14 @@ const preview = (obj: ProjectObj, row: ProjectRow) => {
       }
     }
   }
+}
+</style>
+
+<style lang="scss">
+.project-obj {
+  overflow-y: scroll;
+}
+.project-obj .project-obj-content {
+  overflow: unset;
 }
 </style>


### PR DESCRIPTION
This moves the overflow override outside of the scoped css, which caused the override to not function.

I suspect it was working for me in a previous pr because I was overriding the css in the browser. I have no other ideas as to why it ever appeared to work.