### PR TITLE
Stupid fix to make addons display that they are incompatible

### DIFF
--- a/components/viewer/ViewRequirement.vue
+++ b/components/viewer/ViewRequirement.vue
@@ -4,7 +4,8 @@
     class="obj-requirement"
     :class="{ disabled: !isEnabled }"
   >
-    <span v-if="req.beforeText">{{ req.beforeText }}</span>
+    <span v-if="!req.required && showAlways">Incompatible: </span>
+    <span v-else-if="req.beforeText">{{ req.beforeText }}</span>
     <div v-if="req.type === 'id'">
       <span>{{ getObject(req.reqId)?.title ?? '???' }}</span>
     </div>


### PR DESCRIPTION
This is only a thing because MeanDelay's editor sets the text for addon requirements to always be `Required: ` for addons.

I don't like this because i'm hard coding the text, but there's really no good way to handle this while using MeanDelay's editor and also showing addon requirements.

(MeanDelay's viewer/editor does not show addon requirements ever, and only show addons when the requirements are selected)
