### PR TITLE
[Help Wanted] Remove objects who's requirements are no longer met

### DIFF
--- a/composables/store/project.ts
+++ b/composables/store/project.ts
@@ -115,14 +115,17 @@ export const useProjectStore = defineStore('project', () => {
           selectedN = addOrRemove(objectId, false);
         });
       }
-
-      // Remove any objects that are incompatible with the selected object
-      selectedN = R.pickBy((_, objectId): boolean => {
-        const object = getObject.value(objectId);
-        const pred = buildConditions(object);
-        return pred(R.keys(selectedN));
-      }, selectedN);
     }
+
+    // Remove any objects that do not meet the condition
+    // Removes Incompatible objects, and objects who's requirements are no longer met
+    // TODO: Warn user about incompatible objects or requirements that will be removed,
+    // rather than just removing them
+    selectedN = R.pickBy((_, objectId): boolean => {
+      const object = getObject.value(objectId);
+      const pred = buildConditions(object);
+      return pred(R.keys(selectedN));
+    }, selectedN);
 
     // If allowedChoices is > 0, then there is a limit on the number of objects selected from the same row
     // If allowedChoices is 0, then there is no limit


### PR DESCRIPTION
This was only being performed on selection (as it was intended to remove incompatible objects) but should also remove objects missing requirements.

## Todo
- [ ] Give some indication/warning to a user when deselecting an object will cascade and remove other objects
  - [ ] Abort selection if the user finds this undesirable

