### PR TITLE
Always select backpack

### DIFF
--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -49,6 +49,7 @@
           </template>
           <ViewScores :scores="obj.scores" />
           <ViewRequirements :requireds="obj.requireds" />
+          <!-- eslint-disable-next-line vue/no-v-html -->
           <div class="obj-text" v-html="formatText(obj.text)"></div>
         </div>
       </div>

--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -73,11 +73,13 @@ const {
   obj,
   preview = false,
   width = null,
+  alwaysEnable = false,
 } = defineProps<{
   row: ProjectRow;
   obj: ProjectObj;
   preview?: boolean;
   width?: string;
+  alwaysEnable?: boolean;
 }>();
 
 const objClass = computed(() => {
@@ -96,7 +98,12 @@ const store = useProjectStore();
 const { selectedIds, selected } = useProjectRefs();
 
 const condition = computed(() => buildConditions(obj));
-const isEnabled = computed<boolean>(() => condition.value(selectedIds.value));
+const isEnabled = computed<boolean>(() => {
+  // always enable when alwaysEnable prop is set to true
+  // Used for the backpack, as objects should always be selectable when viewing the backpack
+  if (alwaysEnable) return true;
+  return condition.value(selectedIds.value);
+});
 const isSelected = computed<boolean>(() => R.has(obj.id, selected.value));
 
 const selectedAmount = computed(() => {

--- a/components/viewer/ViewProjectRow.vue
+++ b/components/viewer/ViewProjectRow.vue
@@ -14,6 +14,7 @@
           :alt="row.title"
         />
         <div class="row-title">{{ row.title }}</div>
+        <!-- eslint-disable-next-line vue/no-v-html -->
         <div v-if="row.titleText" class="row-text" v-html="row.titleText" />
       </div>
       <div class="container-fluid p-0">

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -24,7 +24,7 @@
                 :obj="obj"
                 :row="row"
                 :width="packRow.objectWidth"
-                :can-toggle="false"
+                :always-enable="true"
               />
             </div>
           </div>


### PR DESCRIPTION
This fixes items because unselectable when you remove their requirements. While those objects get removed the next time you select an object, it's still an unneeded friction point.

Could revert this if desired if a messaging system/popup around removing objects alongside https://github.com/ltouroumov/cyoa-editor/pull/26