### PR TITLE
Make object preview's sticky

### DIFF
--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -173,6 +173,7 @@ const decrement = () => {
 <style lang="scss">
 .obj-preview {
   overflow: auto;
+  position: sticky;
 }
 .project-obj {
   height: 100%;


### PR DESCRIPTION
QOL change, if you need to scroll the object won't stay in place, you you'd need to scroll back to the top to see whatever you selected. This fixes that.
