### PR TITLE
Add a switch to allow export of legacy build codes

### DIFF
--- a/components/viewer/ViewProjectRow.vue
+++ b/components/viewer/ViewProjectRow.vue
@@ -3,7 +3,7 @@
     <StyleRow
       v-if="row.isPrivateStyling"
       :styles="row.styling"
-      row-id="row.id"
+      :row-id="row.id"
     />
     <div v-show="isVisible" class="project-row">
       <img

--- a/components/viewer/utils/ExportCode.vue
+++ b/components/viewer/utils/ExportCode.vue
@@ -6,6 +6,19 @@
         placeholder="Nothing has been selected yet ..."
         :value="exportCode"
       />
+      <div class="form-check form-switch">
+        <input
+          class="form-check-input"
+          type="checkbox"
+          role="switch"
+          id="flexSwitchCheckChecked"
+          v-model="exportNewCodeStyle"
+          checked
+        />
+        <label class="form-check-label" for="flexSwitchCheckChecked"
+          >Use new style of build codes</label
+        >
+      </div>
       <button
         class="export-code-btn btn btn-outline-primary"
         :class="{ isCopied: isCodeCopied }"
@@ -76,10 +89,20 @@ const packRows = computed(() => {
   );
 });
 
+const exportNewCodeStyle = ref<boolean>(true);
 const exportCode = computed<string>(() => {
+  const join = exportNewCodeStyle.value ? ';' : ',';
+
   return R.pipe(
-    R.map(([id, amt]) => (amt > 1 ? `${id}:${amt}` : id)),
-    R.join(';'),
+    R.map(([id, amt]) => {
+      if (exportNewCodeStyle.value) {
+        return amt > 1 ? `${id}:${amt}` : id;
+      } else {
+        const object = getObject(id);
+        return amt > 1 || object.isSelectableMultiple ? `${id}/ON#${amt}` : id;
+      }
+    }),
+    R.join(join),
   )(R.toPairs(selected.value));
 });
 const exportTextHeaders = ref<boolean>(false);


### PR DESCRIPTION
Adds a switch to export legacy build codes, I've attached a video of how it looks like/functions.

https://github.com/user-attachments/assets/b16ec2a8-8b14-4868-a6ad-82987df8a219

