### PR TITLE
Add toggle to disable backpack group selection

### DIFF
--- a/components/utils/ModalDialog.vue
+++ b/components/utils/ModalDialog.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="modal fade" :class="{ show: show }">
+  <div class="fade modal" :class="{ show: show }">
     <div class="modal-dialog modal-xl">
       <div v-if="show" class="modal-content">
         <div class="modal-header">
@@ -19,7 +19,7 @@
   </div>
   <div
     v-show="show"
-    class="modal-backdrop fade show"
+    class="fade show modal-backdrop"
     @click="$emit('close')"
   ></div>
 </template>

--- a/components/utils/OffCanvas.vue
+++ b/components/utils/OffCanvas.vue
@@ -21,7 +21,7 @@
   </div>
   <div
     v-if="show"
-    class="offcanvas-backdrop fade show"
+    class="fade show offcanvas-backdrop"
     @click="$emit('close')"
   ></div>
 </template>

--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -141,18 +141,19 @@ const isEnabled = computed<boolean>(() => {
   // Whether the object is always enabled or disabled based on the viewObject
   // Otherwise check the object conditions
   switch (viewObject) {
-    case ViewContext.Viewer:
-      return condition.value(selectedIds.value);
-    case ViewContext.Editor:
-      // TODO: Future implementation for editor-specific conditions
-      return true;
     case ViewContext.BackpackEnabled:
       return true;
-    case ViewContext.BackpackDisabled:
-      return false;
     default:
       return condition.value(selectedIds.value);
   }
+});
+const isSelectable = computed<boolean>(() => {
+  return (
+    isEnabled.value &&
+    !obj.isNotSelectable &&
+    !row.isInfoRow &&
+    viewObject !== ViewContext.BackpackDisabled
+  );
 });
 const isSelected = computed<boolean>(() => R.has(obj.id, selected.value));
 
@@ -169,23 +170,18 @@ const maxSelectedAmount = computed(() =>
 );
 
 const toggle = () => {
-  if (
-    isEnabled.value &&
-    !obj.isSelectableMultiple &&
-    !obj.isNotSelectable &&
-    !row.isInfoRow
-  ) {
+  if (isSelectable.value && !obj.isSelectableMultiple) {
     store.setSelected(obj.id, !isSelected.value);
   }
 };
 
 const increment = () => {
-  if (isEnabled.value) {
+  if (isSelectable.value) {
     store.incSelected(obj.id);
   }
 };
 const decrement = () => {
-  if (isEnabled.value) {
+  if (isSelectable.value) {
     store.decSelected(obj.id);
   }
 };

--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -80,7 +80,7 @@ import { buildConditions } from '~/composables/conditions';
 import { ProjectObj, ProjectRow } from '~/composables/project';
 import { useProjectRefs, useProjectStore } from '~/composables/store/project';
 import { formatText } from '~/composables/text';
-import { ViewObject } from '~/composables/viewer';
+import { ViewContext } from '~/composables/viewer';
 
 const {
   row,
@@ -92,14 +92,13 @@ const {
 } = defineProps<{
   row: ProjectRow;
   obj: ProjectObj;
-  viewObject?: ViewObject;
+  viewObject?: ViewContext;
   width?: string;
   forceWidth?: string;
   template?: string;
 }>();
 
 const objClass = computed(() => {
-  if (viewObject === ViewObject.Preview) return ['obj-preview'];
   if (forceWidth) return ['col', { [forceWidth]: true }];
 
   let objectSize = row.objectWidth;
@@ -142,9 +141,14 @@ const isEnabled = computed<boolean>(() => {
   // Whether the object is always enabled or disabled based on the viewObject
   // Otherwise check the object conditions
   switch (viewObject) {
-    case ViewObject.AlwaysEnabled:
+    case ViewContext.Viewer:
+      return condition.value(selectedIds.value);
+    case ViewContext.Editor:
+      // TODO: Future implementation for editor-specific conditions
       return true;
-    case ViewObject.AlwaysDisabled:
+    case ViewContext.BackpackEnabled:
+      return true;
+    case ViewContext.BackpackDisabled:
       return false;
     default:
       return condition.value(selectedIds.value);

--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -80,27 +80,26 @@ import { buildConditions } from '~/composables/conditions';
 import { ProjectObj, ProjectRow } from '~/composables/project';
 import { useProjectRefs, useProjectStore } from '~/composables/store/project';
 import { formatText } from '~/composables/text';
+import { ViewObject } from '~/composables/viewer';
 
 const {
   row,
   obj,
-  preview = false,
+  viewObject,
   width = null,
   forceWidth = null,
-  alwaysEnable = false,
   template = null,
 } = defineProps<{
   row: ProjectRow;
   obj: ProjectObj;
-  preview?: boolean;
+  viewObject: ViewObject;
   width?: string;
   forceWidth?: string;
-  alwaysEnable?: boolean;
   template?: string;
 }>();
 
 const objClass = computed(() => {
-  if (preview) return ['obj-preview'];
+  if (viewObject === ViewObject.Preview) return ['obj-preview'];
   if (forceWidth) return ['col', { [forceWidth]: true }];
 
   let objectSize = row.objectWidth;
@@ -140,10 +139,16 @@ const { selectedIds, selected } = useProjectRefs();
 
 const condition = computed(() => buildConditions(obj));
 const isEnabled = computed<boolean>(() => {
-  // always enable when alwaysEnable prop is set to true
-  // Used for the backpack, as objects should always be selectable when viewing the backpack
-  if (alwaysEnable) return true;
-  return condition.value(selectedIds.value);
+  // Whether the object is always enabled or disabled based on the viewObject
+  // Otherwise check the object conditions
+  switch (viewObject) {
+    case ViewObject.AlwaysEnabled:
+      return true;
+    case ViewObject.AlwaysDisabled:
+      return false;
+    default:
+      return condition.value(selectedIds.value);
+  }
 });
 const isSelected = computed<boolean>(() => R.has(obj.id, selected.value));
 

--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -92,7 +92,7 @@ const {
 } = defineProps<{
   row: ProjectRow;
   obj: ProjectObj;
-  viewObject: ViewObject;
+  viewObject?: ViewObject;
   width?: string;
   forceWidth?: string;
   template?: string;

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -24,7 +24,7 @@
                 :obj="obj"
                 :row="row"
                 :width="packRow.objectWidth"
-                :always-enable="true"
+                :view-object="ViewObject.AlwaysEnabled"
               />
             </div>
           </div>
@@ -48,6 +48,7 @@ import ImportCode from '~/components/viewer/utils/ImportCode.vue';
 import { ProjectObj, ProjectRow } from '~/composables/project';
 import { useProjectRefs, useProjectStore } from '~/composables/store/project';
 import { useViewerRefs, useViewerStore } from '~/composables/store/viewer';
+import { ViewObject } from '~/composables/viewer';
 
 const { getObject, getObjectRow, getRow } = useProjectStore();
 const { selected, backpack } = useProjectRefs();

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -16,7 +16,6 @@
               class="form-check-input"
               type="checkbox"
               role="switch"
-              @change="toggleRowSelectable"
             />
             <label class="form-check-label" for="packRowDisabledSwitch">
               Disable Backpack Selection
@@ -106,9 +105,6 @@ const packRows = computed(() => {
 });
 
 const disableBackpackSelectionSwitch = ref(false);
-const toggleRowSelectable = () => {
-  return !disableBackpackSelectionSwitch.value;
-};
 </script>
 
 <style scoped lang="scss">

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -39,7 +39,7 @@
                 :obj="obj"
                 :row="row"
                 :width="packRow.objectWidth"
-                :view-object="ViewObject.AlwaysEnabled"
+                :view-object="ViewContext.BackpackEnabled"
               />
             </div>
             <div v-else class="row g-2">
@@ -49,7 +49,7 @@
                 :obj="obj"
                 :row="row"
                 :width="packRow.objectWidth"
-                :view-object="ViewObject.AlwaysDisabled"
+                :view-object="ViewContext.BackpackDisabled"
               />
             </div>
           </div>
@@ -73,7 +73,7 @@ import ImportCode from '~/components/viewer/utils/ImportCode.vue';
 import { ProjectObj, ProjectRow } from '~/composables/project';
 import { useProjectRefs, useProjectStore } from '~/composables/store/project';
 import { useViewerRefs, useViewerStore } from '~/composables/store/viewer';
-import { ViewObject } from '~/composables/viewer';
+import { ViewContext } from '~/composables/viewer';
 
 const { getObject, getObjectRow, getRow } = useProjectStore();
 const { selected, backpack } = useProjectRefs();

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -125,8 +125,6 @@ const toggleRowSelectable = () => {
 
   .pack-info-container {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
     position: relative;
 
     .pack-scores {

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -175,11 +175,11 @@ const toggleRowSelectable = () => {
     flex-direction: column;
   }
 
-  .pack-row .pack-row-title-container {
+  .pack-content .pack-info-container {
     flex-direction: column;
     align-items: flex-start;
 
-    .pack-row-controls {
+    .pack-selection-controls {
       position: unset;
     }
   }

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -5,34 +5,34 @@
     </template>
     <template #default>
       <div class="pack-content flex-grow-1 bg-dark">
-        <div class="pack-scores">
-          <ViewScoreStatus vertical />
+        <div class="pack-info-container">
+          <div class="pack-scores">
+            <ViewScoreStatus vertical />
+          </div>
+          <div class="form-check form-switch pack-selection-controls">
+            <input
+              id="packRowDisabledSwitch"
+              v-model="disableBackpackSelectionSwitch"
+              class="form-check-input"
+              type="checkbox"
+              role="switch"
+              @change="toggleRowSelectable"
+            />
+            <label class="form-check-label" for="packRowDisabledSwitch">
+              Disable Backpack Selection
+            </label>
+          </div>
         </div>
         <div
           v-for="{ packRow, choices } in packRows"
           :key="packRow.id"
           class="pack-row"
         >
-          <div class="pack-row-title-container">
-            <div class="pack-row-title">
-              {{ packRow.title }}
-            </div>
-            <div class="form-check form-switch pack-row-controls">
-              <input
-                id="packRowDisabledSwitch"
-                v-model="disabledPackRowSwitch[packRow.id]"
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                @change="toggleRowSelectable(packRow)"
-              />
-              <label class="form-check-label" for="packRowDisabledSwitch">
-                Disable Row
-              </label>
-            </div>
+          <div class="pack-row-title">
+            {{ packRow.title }}
           </div>
           <div class="container-fluid p-0">
-            <div v-if="!disabledSelected.includes(packRow.id)" class="row g-2">
+            <div v-if="!disableBackpackSelectionSwitch" class="row g-2">
               <ViewProjectObj
                 v-for="{ obj, row } in choices"
                 :key="obj.id"
@@ -105,26 +105,9 @@ const packRows = computed(() => {
   );
 });
 
-const disabledSelected = ref<string[]>([]);
-type PackRowSwitchStates = Record<string, boolean>;
-const disabledPackRowSwitch = ref<PackRowSwitchStates>(
-  R.reduce(
-    (acc, obj) =>
-      R.assoc(
-        obj.packRow.id,
-        R.includes(obj.packRow.id, disabledSelected.value),
-        acc,
-      ),
-    {},
-    packRows.value,
-  ),
-);
-const toggleRowSelectable = (packRow: ProjectRow) => {
-  if (R.includes(packRow.id, disabledSelected.value)) {
-    disabledSelected.value = R.without([packRow.id], disabledSelected.value);
-  } else {
-    disabledSelected.value = R.concat(disabledSelected.value, [packRow.id]);
-  }
+const disableBackpackSelectionSwitch = ref(false);
+const toggleRowSelectable = () => {
+  return !disableBackpackSelectionSwitch.value;
 };
 </script>
 
@@ -140,32 +123,31 @@ const toggleRowSelectable = (packRow: ProjectRow) => {
   overflow-x: hidden;
   overflow-y: auto;
 
-  .pack-scores {
-    margin-bottom: 0.5rem;
+  .pack-info-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    position: relative;
+
+    .pack-scores {
+      margin-bottom: 0.5rem;
+    }
+
+    .pack-selection-controls {
+      position: absolute;
+      right: 0;
+    }
   }
 
   .pack-row {
     padding: 0;
     margin-bottom: 0.5rem;
 
-    .pack-row-title-container {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      position: relative;
-    }
-
     .pack-row-title {
       font-size: 1.2rem;
       font-weight: bolder;
       text-align: center;
       margin-bottom: 0.2rem;
-      flex: 1;
-    }
-
-    .pack-row-controls {
-      position: absolute;
-      right: 0;
     }
 
     .choice {

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -13,11 +13,26 @@
           :key="packRow.id"
           class="pack-row"
         >
-          <div class="pack-row-title">
-            {{ packRow.title }}
+          <div class="pack-row-title-container">
+            <div class="pack-row-title">
+              {{ packRow.title }}
+            </div>
+            <div class="form-check form-switch pack-row-controls">
+              <input
+                id="packRowDisabledSwitch"
+                v-model="disabledPackRowSwitch"
+                class="form-check-input"
+                type="checkbox"
+                role="switch"
+                @change="toggleRowSelectable(packRow)"
+              />
+              <label class="form-check-label" for="packRowDisabledSwitch">
+                Disable Row
+              </label>
+            </div>
           </div>
           <div class="container-fluid p-0">
-            <div class="row g-2">
+            <div v-if="!disabledSelected.includes(packRow.id)" class="row g-2">
               <ViewProjectObj
                 v-for="{ obj, row } in choices"
                 :key="obj.id"
@@ -25,6 +40,16 @@
                 :row="row"
                 :width="packRow.objectWidth"
                 :view-object="ViewObject.AlwaysEnabled"
+              />
+            </div>
+            <div v-else class="row g-2">
+              <ViewProjectObj
+                v-for="{ obj, row } in choices"
+                :key="obj.id"
+                :obj="obj"
+                :row="row"
+                :width="packRow.objectWidth"
+                :view-object="ViewObject.AlwaysDisabled"
               />
             </div>
           </div>
@@ -79,6 +104,16 @@ const packRows = computed(() => {
     backpack.value,
   );
 });
+
+const disabledSelected = ref<string[]>([]);
+const disabledPackRowSwitch = ref(false);
+const toggleRowSelectable = (packRow: ProjectRow) => {
+  if (R.includes(packRow.id, disabledSelected.value)) {
+    disabledSelected.value = R.without([packRow.id], disabledSelected.value);
+  } else {
+    disabledSelected.value = R.concat(disabledSelected.value, [packRow.id]);
+  }
+};
 </script>
 
 <style scoped lang="scss">
@@ -101,11 +136,24 @@ const packRows = computed(() => {
     padding: 0;
     margin-bottom: 0.5rem;
 
+    .pack-row-title-container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      position: relative;
+    }
+
     .pack-row-title {
       font-size: 1.2rem;
       font-weight: bolder;
       text-align: center;
       margin-bottom: 0.2rem;
+      flex: 1;
+    }
+
+    .pack-row-controls {
+      position: absolute;
+      right: 0;
     }
 
     .choice {
@@ -131,6 +179,15 @@ const packRows = computed(() => {
 @media screen and (max-width: 768px) {
   .pack-import-export {
     flex-direction: column;
+  }
+
+  .pack-row .pack-row-title-container {
+    flex-direction: column;
+    align-items: flex-start;
+
+    .pack-row-controls {
+      position: unset;
+    }
   }
 }
 </style>

--- a/components/viewer/modal/BackpackModal.vue
+++ b/components/viewer/modal/BackpackModal.vue
@@ -20,7 +20,7 @@
             <div class="form-check form-switch pack-row-controls">
               <input
                 id="packRowDisabledSwitch"
-                v-model="disabledPackRowSwitch"
+                v-model="disabledPackRowSwitch[packRow.id]"
                 class="form-check-input"
                 type="checkbox"
                 role="switch"
@@ -106,7 +106,19 @@ const packRows = computed(() => {
 });
 
 const disabledSelected = ref<string[]>([]);
-const disabledPackRowSwitch = ref(false);
+type PackRowSwitchStates = Record<string, boolean>;
+const disabledPackRowSwitch = ref<PackRowSwitchStates>(
+  R.reduce(
+    (acc, obj) =>
+      R.assoc(
+        obj.packRow.id,
+        R.includes(obj.packRow.id, disabledSelected.value),
+        acc,
+      ),
+    {},
+    packRows.value,
+  ),
+);
 const toggleRowSelectable = (packRow: ProjectRow) => {
   if (R.includes(packRow.id, disabledSelected.value)) {
     disabledSelected.value = R.without([packRow.id], disabledSelected.value);

--- a/components/viewer/modal/SearchModal.vue
+++ b/components/viewer/modal/SearchModal.vue
@@ -37,7 +37,7 @@
             :key="searchView.obj.id"
             :obj="searchView.obj"
             :row="searchView.row"
-            :view-object="ViewObject.Preview"
+            :view-object="ViewContext.Viewer"
             template="1"
           />
         </div>
@@ -53,7 +53,7 @@ import { all, any, includes, isEmpty } from 'ramda';
 import { Project, ProjectObj, ProjectRow } from '~/composables/project';
 import { useProjectRefs } from '~/composables/store/project';
 import { useViewerRefs, useViewerStore } from '~/composables/store/viewer';
-import { ViewObject } from '~/composables/viewer';
+import { ViewContext } from '~/composables/viewer';
 
 const { toggleSearch } = useViewerStore();
 const { isSearchVisible } = useViewerRefs();

--- a/components/viewer/modal/SearchModal.vue
+++ b/components/viewer/modal/SearchModal.vue
@@ -37,7 +37,7 @@
             :key="searchView.obj.id"
             :obj="searchView.obj"
             :row="searchView.row"
-            preview
+            :view-object="ViewObject.Preview"
             template="1"
           />
         </div>
@@ -53,6 +53,7 @@ import { all, any, includes, isEmpty } from 'ramda';
 import { Project, ProjectObj, ProjectRow } from '~/composables/project';
 import { useProjectRefs } from '~/composables/store/project';
 import { useViewerRefs, useViewerStore } from '~/composables/store/viewer';
+import { ViewObject } from '~/composables/viewer';
 
 const { toggleSearch } = useViewerStore();
 const { isSearchVisible } = useViewerRefs();

--- a/components/viewer/utils/ExportCode.vue
+++ b/components/viewer/utils/ExportCode.vue
@@ -34,7 +34,7 @@
         placeholder="Nothing has been selected yet ..."
         :value="exportText"
       />
-      <div class="export-text-toggle form-check form-switch">
+      <div class="form-check form-switch export-text-toggle">
         <input
           id="sectionTitleSwitch"
           v-model="exportTextHeaders"

--- a/composables/viewer.ts
+++ b/composables/viewer.ts
@@ -7,9 +7,9 @@ export type ViewerProjectList = {
   items: ViewerProject[];
 };
 
-export enum ViewObject {
-  Preview,
+export enum ViewContext {
+  Viewer,
   Editor, // Future use case
-  AlwaysEnabled,
-  AlwaysDisabled,
+  BackpackEnabled,
+  BackpackDisabled,
 }

--- a/composables/viewer.ts
+++ b/composables/viewer.ts
@@ -6,3 +6,10 @@ export type ViewerProject = {
 export type ViewerProjectList = {
   items: ViewerProject[];
 };
+
+export enum ViewObject {
+  Preview,
+  Editor, // Future use case
+  AlwaysEnabled,
+  AlwaysDisabled,
+}


### PR DESCRIPTION
Desktop css might need some tweaking, how it's managed in general is a little more hacky than I'd prefer. For some reason vue won't handle reactivity with enums the way I'd prefer.