### PR TITLE
Remove unneeded spans

### DIFF
--- a/components/viewer/ViewScore.vue
+++ b/components/viewer/ViewScore.vue
@@ -1,14 +1,12 @@
 <template>
   <div class="obj-score" :class="{ disabled: !isEnabled }">
-    <span v-if="score.beforeText" class="score-before">{{
-      score.beforeText
-    }}</span>
-    <span class="score-value">{{
-      Math.abs(Number.parseInt(score.value))
-    }}</span>
-    <span v-if="score.afterText" class="score-after">{{
+    {{
+      score.beforeText +
+      ' ' +
+      Math.abs(Number.parseInt(score.value)) +
+      ' ' +
       score.afterText
-    }}</span>
+    }}
   </div>
 </template>
 


### PR DESCRIPTION
Fixes ctrl - f for searching

I'm not sure if this is the proper way, however, keeping the spans does prevent browsers from considering them the same line of text, therefore breaking ctrl-f searching.