### PR TITLE
Put check for disabled images on the correct object

### DIFF
--- a/components/viewer/ViewProjectObj.vue
+++ b/components/viewer/ViewProjectObj.vue
@@ -17,9 +17,9 @@
       @click="toggle"
     >
       <div class="project-obj-content" :class="objTemplateClass">
-        <div v-if="!disableImages" class="obj-image-wrapper">
+        <div class="obj-image-wrapper">
           <img
-            v-if="obj.image"
+            v-if="obj.image && !disableImages"
             class="obj-image"
             :decoding="alwaysEnable ? `sync` : `auto`"
             :loading="alwaysEnable ? `eager` : `lazy`"


### PR DESCRIPTION
Somehow I put it on the container *instead* of the image. Whoops.